### PR TITLE
Update 16.1 - Includes breaking changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ DockerConfigurationMiddleware.ConfigureDockerSqlDb(builder.Configuration);
 ```json
 "environmentVariables": {
   "Use_Local_Docker_SQL": "true",
+  "Local_Docker_PROJECT_NAME": "MyProject",
+  "Local_Docker_CONTAINER_DIRECTORY_OVERRIDE": "C:\\a\\path\\to\\goto",
   "Local_Docker_DB_NAME": "MyDatabase",
   "Local_Docker_PASSWORD": "YourStrongPassword123",
   "Local_Docker_PORT": "1433"


### PR DESCRIPTION
Originally the package forced the docker container to spin up within the Runtime folder decided by: AppContext.BaseDirectory
This caused issues in the scenario that you would update the Umbraco version through to a new .net core version, resulting in the Middleware looking in the wrong directory for the previously set up container / DB.

I have included two new optional launchSettings variables to allow users to define their own container directory as well as decide the project name of the docker container. Allowing the package to be truly .net agnostic.

This however does include a breaking change that if a user updates to this version on a previously working installation, they will need to use the two new properties to set their container back to what it was originally.

As an example, if you're project originally lived in C:\Work\WebsiteRepo\ and was on .net core 8.0
You would set the following two properties as so:

"Local_Docker_CONTAINER_DIRECTORY_OVERRIDE": "C:\Work\WebsiteRepo\bin\Debug\net.8.0"
"Local_Docker_PROJECT_NAME": "net80",