### PR TITLE
Changing core reference to be a bounding range

### DIFF
--- a/src/Webwonders.Umbraco.DockerConfiguration/Webwonders.Umbraco.DockerConfiguration.csproj
+++ b/src/Webwonders.Umbraco.DockerConfiguration/Webwonders.Umbraco.DockerConfiguration.csproj
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
         <PackageReference Include="Umbraco.Cms.Core" Version="[13.0.0,15.0.0)" Condition="'$(TargetFramework)' == 'net8.0'" ExcludeAssets="runtime"/>
-        <PackageReference Include="Umbraco.Cms.Core" Version="16.*" Condition="'$(TargetFramework)' == 'net9.0'" ExcludeAssets="runtime"/>
+        <PackageReference Include="Umbraco.Cms.Core" Version="[16.0.0,17.0.0)" Condition="'$(TargetFramework)' == 'net9.0'" ExcludeAssets="runtime"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Instead of the csproj referencing direct call to 16.* we have changed it to a bounding call to allow it to work for all 16 versions.